### PR TITLE
fix: prevent infinite event reload loop

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -60,29 +60,6 @@ export default function EventsScreen() {
 
   // Favorites integration
   const { isFavorite, toggleFavorite } = useFavorites();
-
-
-  // Load events when component mounts
-  useEffect(() => {
-    if (hasLocation || isDefaultLocation) {
-      loadEventsWithLocation();
-    }
-  }, []); // Only run once on mount
-
-  // Reload when location changes
-  useEffect(() => {
-    if (hasLocation || isDefaultLocation) {
-      loadEventsWithLocation();
-    }
-  }, [hasLocation, isDefaultLocation]);
-
-  // Reload when filters change
-  useEffect(() => {
-    if (hasLocation || isDefaultLocation) {
-      loadEventsWithLocation();
-    }
-  }, [filters]);
-
   // Load events function for refresh
   const loadEventsWithLocation = useCallback(async (refreshing = false) => {
     if (!hasLocation && !isDefaultLocation) return;
@@ -133,6 +110,13 @@ export default function EventsScreen() {
       }));
     }
   }, [hasLocation, isDefaultLocation, filters, location]);
+
+  // Load events whenever location or filters change
+  useEffect(() => {
+    if (hasLocation || isDefaultLocation) {
+      loadEventsWithLocation();
+    }
+  }, [loadEventsWithLocation, hasLocation, isDefaultLocation]);
 
   const handleRefresh = useCallback(() => {
     loadEventsWithLocation(true);


### PR DESCRIPTION
## Summary
- consolidate event loading into a single effect
- avoid cascading setState calls that triggered maximum update depth errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab6a9a9528832d8485feb7d2370add