### PR TITLE
Refactor favorites hook to avoid duplicate storage reads

### DIFF
--- a/hooks/useFavorites.ts
+++ b/hooks/useFavorites.ts
@@ -66,8 +66,8 @@ export function useFavorites(): UseFavoritesResult {
     
     try {
       const favorites = await favoritesService.getFavorites();
-      const favoriteIds = await favoritesService.getFavoriteIds();
-      
+      const favoriteIds = new Set(favorites.map(f => f.id));
+
       setState(prev => ({
         ...prev,
         favorites,


### PR DESCRIPTION
## Summary
- derive favorite ID Set from favorites in `useFavorites` to avoid extra storage fetch

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab748101b0832da1d0ef60a67a8a71