### PR TITLE
Optimize favorite filtering in event processing

### DIFF
--- a/services/EventProcessor.ts
+++ b/services/EventProcessor.ts
@@ -47,9 +47,14 @@ export class EventProcessor {
     this.artMapCache = await dataService.getArtMap();
     this.campMapCache = await dataService.getCampMap();
 
-    const hasGPS = typeof lat === 'number' && typeof lon === 'number' && 
+    const hasGPS = typeof lat === 'number' && typeof lon === 'number' &&
                    Number.isFinite(lat) && Number.isFinite(lon);
     const upcomingCutoff = new Date(now.getTime() + timeWindow * 60 * 1000);
+
+    // Pre-fetch favorite IDs when filtering by favorites to avoid repeated async calls
+    const favoriteIds = showOnlyFavorites
+      ? await favoritesService.getFavoriteIds()
+      : null;
 
     const processedEvents: ProcessedEvent[] = [];
 
@@ -99,8 +104,7 @@ export class EventProcessor {
         // Apply favorites filter
         if (showOnlyFavorites) {
           const eventId = `${event.uid}_${occurrence.start_time}`;
-          const isFavorite = await favoritesService.isFavorite(eventId);
-          if (!isFavorite) {
+          if (!favoriteIds?.has(eventId)) {
             continue;
           }
         }


### PR DESCRIPTION
## Summary
- Batch favorite lookups by loading all favorite IDs once
- Check favorite membership synchronously during event filtering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab748963f4832d95a16dcc733181f6