### PR TITLE
Fix infinite render loop in events screen

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -111,12 +111,14 @@ export default function EventsScreen() {
     }
   }, [hasLocation, isDefaultLocation, filters, location]);
 
-  // Load events whenever location or filters change
+  // Load events whenever location or filters change. Avoid including the
+  // memoized function itself in the dependency array to prevent it from
+  // being treated as a changing dependency on every render.
   useEffect(() => {
     if (hasLocation || isDefaultLocation) {
       loadEventsWithLocation();
     }
-  }, [loadEventsWithLocation, hasLocation, isDefaultLocation]);
+  }, [hasLocation, isDefaultLocation, filters, location]);
 
   const handleRefresh = useCallback(() => {
     loadEventsWithLocation(true);


### PR DESCRIPTION
## Summary
- Prevent useEffect in events screen from re-triggering endlessly
- Add explanatory comment about dependency array

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab75262538832da3a2d30d021946d2