### PR TITLE
test: add unit tests for components hooks and utils

### DIFF
--- a/__tests__/CountdownTimer.test.tsx
+++ b/__tests__/CountdownTimer.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import CountdownTimer from '../components/CountdownTimer';
+
+// The component uses timers internally, so use fake timers to control time
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('CountdownTimer', () => {
+  it('shows start time when event has not started', () => {
+    const start = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes from now
+    const end = new Date(Date.now() + 70 * 60 * 1000); // 70 minutes from now
+
+    render(<CountdownTimer start={start} end={end} />);
+
+    expect(screen.getByText(/Starts in 10m/)).toBeTruthy();
+  });
+
+  it('shows remaining time when event is active', () => {
+    const start = new Date(Date.now() - 10 * 60 * 1000); // started 10m ago
+    const end = new Date(Date.now() + 50 * 60 * 1000); // ends in 50m
+
+    render(<CountdownTimer start={start} end={end} />);
+
+    expect(screen.getByText(/Ends in 50m/)).toBeTruthy();
+    const timer = screen.getByA11yRole('timer');
+    expect(timer.props.accessibilityLabel).toContain('Event is happening now');
+  });
+
+  it('shows ended state when event is over', () => {
+    const start = new Date(Date.now() - 120 * 60 * 1000); // started 2h ago
+    const end = new Date(Date.now() - 60 * 60 * 1000); // ended 1h ago
+
+    render(<CountdownTimer start={start} end={end} />);
+
+    expect(screen.getByText(/Ended/)).toBeTruthy();
+  });
+});

--- a/__tests__/DesertButton.test.tsx
+++ b/__tests__/DesertButton.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { DesertButton } from '../components/DesertButton';
+
+// Mock theme constants used by the component
+jest.mock('@/constants/Theme', () => ({
+  TouchTargets: {},
+  Spacing: { sm: 8, md: 16, lg: 24 },
+  AccessibilityConfig: {
+    touch: { hapticFeedback: false },
+    visual: { animationDuration: { short: 100 } },
+  },
+}), { virtual: true });
+
+// Mock useDesertTheme hook to provide minimal theme values
+jest.mock('../components/DesertThemeProvider', () => ({
+  useDesertTheme: () => ({
+    colors: {
+      playaOrange: 'orange',
+      overlay: 'rgba(0,0,0,0.1)',
+      dustGray: 'gray',
+      statusEnded: 'maroon',
+      brightWhite: '#fff',
+      nightBlack: '#000',
+    },
+    shouldUseHighContrast: false,
+    getFontScale: () => 1,
+    getAnimationDuration: (d:number) => d,
+    getOpacity: (o:number) => o,
+    getColorScheme: () => 'light' as const,
+    isScreenReaderActive: false,
+    shouldReduceMotion: false,
+    shouldReduceTransparency: false,
+    textShadowStyle: {},
+    focusStyle: { borderWidth: 1, borderColor: '#000' },
+  }),
+}));
+
+// Mock useThemeColor used by ThemedText inside button
+jest.mock('@/hooks/useThemeColor', () => ({
+  useThemeColor: () => '#000',
+}), { virtual: true });
+
+describe('DesertButton', () => {
+  it('fires onPress when pressed', () => {
+    const onPress = jest.fn();
+    render(<DesertButton title="Press me" onPress={onPress} />);
+    fireEvent.press(screen.getByText('Press me'));
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  it('does not fire onPress when disabled', () => {
+    const onPress = jest.fn();
+    render(<DesertButton title="Press me" onPress={onPress} disabled />);
+    fireEvent.press(screen.getByText('Press me'));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onPress when loading', () => {
+    const onPress = jest.fn();
+    render(<DesertButton title="Press me" onPress={onPress} loading />);
+    fireEvent.press(screen.getByText('Press me'));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/timeUtils.test.ts
+++ b/__tests__/timeUtils.test.ts
@@ -1,0 +1,71 @@
+import {
+  formatCountdown,
+  getRelativeTime,
+  getCountdownInfo,
+  parseOccurrenceSet,
+  formatDuration,
+} from '../utils/timeUtils';
+
+describe('timeUtils', () => {
+  describe('formatCountdown', () => {
+    it('formats minutes under an hour', () => {
+      expect(formatCountdown(45)).toBe('45m');
+    });
+
+    it('formats full hours', () => {
+      expect(formatCountdown(120)).toBe('2h');
+    });
+
+    it('formats hours and minutes', () => {
+      expect(formatCountdown(150)).toBe('2h 30m');
+    });
+  });
+
+  describe('getRelativeTime', () => {
+    it('returns future times', () => {
+      const now = new Date('2025-01-01T00:00:00Z');
+      const target = new Date(now.getTime() + 30 * 60000);
+      const result = getRelativeTime(target, now);
+      expect(result).toEqual({ text: 'in 30m', isPast: false, isNear: false });
+    });
+
+    it('returns past times', () => {
+      const now = new Date('2025-01-01T00:00:00Z');
+      const target = new Date(now.getTime() - 10 * 60000);
+      const result = getRelativeTime(target, now);
+      expect(result).toEqual({ text: '10m ago', isPast: true, isNear: true });
+    });
+  });
+
+  describe('getCountdownInfo', () => {
+    it('identifies active events', () => {
+      const now = new Date('2025-01-01T00:00:00Z');
+      const start = new Date(now.getTime() - 5 * 60000);
+      const end = new Date(now.getTime() + 5 * 60000);
+      const info = getCountdownInfo(start, end, now);
+      expect(info.isActive).toBe(true);
+      expect(info.isStartingSoon).toBe(false);
+      expect(info.isEndingSoon).toBe(true);
+    });
+  });
+
+  describe('parseOccurrenceSet', () => {
+    it('filters invalid entries', () => {
+      const occurrences = [
+        { start_time: '2025-01-01T00:00:00Z', end_time: '2025-01-01T01:00:00Z' },
+        { start_time: 'bad', end_time: 'data' },
+      ];
+      const parsed = parseOccurrenceSet(occurrences);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].start instanceof Date).toBe(true);
+    });
+  });
+
+  describe('formatDuration', () => {
+    it('formats durations with days and hours', () => {
+      const start = new Date('2025-01-01T00:00:00Z');
+      const end = new Date('2025-01-03T03:00:00Z');
+      expect(formatDuration(start, end)).toBe('2d 3h');
+    });
+  });
+});

--- a/__tests__/useFavorites.test.ts
+++ b/__tests__/useFavorites.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useFavorites } from '../hooks/useFavorites';
+import { favoritesService } from '../services/FavoritesService';
+
+const favoriteEvent = {
+  id: '1',
+  eventUid: 'u1',
+  title: 'Test Event',
+  start: new Date(),
+  end: new Date(Date.now() + 60 * 60 * 1000),
+  type: 'Party',
+  typeAbbr: 'prty',
+  locLabel: 'Camp',
+};
+
+const getFavoritesMock = jest.fn().mockResolvedValue([]);
+
+jest.mock('../services/FavoritesService', () => ({
+  favoritesService: {
+    getFavorites: getFavoritesMock,
+    addFavorite: jest.fn().mockResolvedValue(undefined),
+    removeFavorite: jest.fn().mockResolvedValue(undefined),
+    toggleFavorite: jest.fn().mockResolvedValue(true),
+    clearAllFavorites: jest.fn().mockResolvedValue(undefined),
+    getFavoritesCount: jest.fn().mockResolvedValue(0),
+    exportFavorites: jest.fn().mockResolvedValue(''),
+  },
+}));
+
+describe('useFavorites', () => {
+  beforeEach(() => {
+    getFavoritesMock.mockResolvedValue([]);
+  });
+
+  it('loads favorites on mount', async () => {
+    const { result } = renderHook(() => useFavorites());
+    await act(async () => {}); // wait for useEffect
+    expect(result.current.favorites).toHaveLength(0);
+    expect(favoritesService.getFavorites).toHaveBeenCalled();
+  });
+
+  it('adds a favorite and refreshes state', async () => {
+    getFavoritesMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([favoriteEvent]);
+
+    const { result } = renderHook(() => useFavorites());
+    await act(async () => {}); // initial load
+
+    await act(async () => {
+      await result.current.addFavorite(favoriteEvent);
+    });
+
+    expect(favoritesService.addFavorite).toHaveBeenCalledWith(favoriteEvent);
+    expect(result.current.favorites).toHaveLength(1);
+    expect(result.current.count).toBe(1);
+    expect(result.current.isFavorite('1')).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",


### PR DESCRIPTION
## Summary
- add comprehensive tests for CountdownTimer component covering upcoming, active, and ended states
- add DesertButton interaction tests with disabled and loading safeguards
- test useFavorites hook actions and state updates with mocked service
- cover time utilities like countdown formatting, relative times, and duration helpers
- add npm `test` script to run Jest

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab766af82c832d9da0a6041e35bac3